### PR TITLE
Add missing seed option -s to getopt()

### DIFF
--- a/menace.lua
+++ b/menace.lua
@@ -416,7 +416,7 @@ local readonly = false
 local ngames = 500000
 local seed = os.time()
 
-for opt, arg in getopt(arg, 'b:hirn:') do
+for opt, arg in getopt(arg, 'b:hirn:s:') do
     if opt == 'b' then
         brainfile = arg
     elseif opt == 'h' then


### PR DESCRIPTION
Apparently the option to give a seed (-s) is missing from `getopt()`.

By the way, I noticed a funny coincidence: the letters "hirn" from `b:hirn:s:` happen to be the German word for brain 😉 